### PR TITLE
changes license to Apache 2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,20 +2,15 @@ The MIT License (MIT)
 
 Copyright (c) 2016 SparkPost
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this software except in compliance with the License.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+A copy of the License is located at
+
+http://www.apache.org/licenses/LICENSE-2.0.html
+
+or in the "license" file accompanying this software. This file is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.

--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ transmission level. Merge data for recipients (e.g., `provider.merge['email@exam
 data for that recipient.
 
 ## License
-MIT
+Apache 2.0

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "email": "developers@sparkpost.com",
     "url": "https://developers.sparkpost.com"
   },
-  "license": "MIT",
+  "license": "Apache 2.0",
   "bugs": {
     "url": "https://github.com/SparkPost/campaign-sparkpost/issues"
   },


### PR DESCRIPTION
Apache 2 is our approved license, so switch from MIT
